### PR TITLE
Use `OrderedDict` for `variable_symbols`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/Project.toml
+++ b/Project.toml
@@ -6,22 +6,11 @@ version = "0.2.0"
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
+OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
 SciMLBase = "0bca4576-84f4-4d90-8ffe-ffa030f20462"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 SymbolicIndexingInterface = "2efcf032-c050-4f8e-a9bb-153293bab1f5"
-
-[compat]
-julia = "1.10"
-Accessors = "0.1"
-ConstructionBase = "1.5"
-OhMyThreads = "0.6, 0.7"
-RecursiveArrayTools = "3"
-SciMLBase = "2"
-SparseArrays = "1"
-SymbolicIndexingInterface = "0.3"
-Symbolics = "6"
-ModelingToolkit = "9"
 
 [weakdeps]
 ModelingToolkit = "961ee093-0014-501f-94e3-6117800e7a78"
@@ -29,6 +18,19 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]
 MTKExt = ["Symbolics", "ModelingToolkit"]
+
+[compat]
+Accessors = "0.1"
+ConstructionBase = "1.5"
+ModelingToolkit = "9"
+OhMyThreads = "0.6, 0.7"
+OrderedCollections = "1.6.3"
+RecursiveArrayTools = "3"
+SciMLBase = "2"
+SparseArrays = "1"
+SymbolicIndexingInterface = "0.3"
+Symbolics = "6"
+julia = "1.10"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -98,6 +98,11 @@ using SparseArrays:
     rowvals,
     nzrange
 
+using OrderedCollections:
+    OrderedCollections,
+    OrderedDict
+
+
 #----------------------------------------------------------
 # Random utils
 include("utils.jl")

--- a/src/symbolic_indexing.jl
+++ b/src/symbolic_indexing.jl
@@ -16,7 +16,7 @@ struct ParamIndex #todo: this'll require some generalization to support weight p
 end
 
 function compute_namemap(names_partitioned, states_partitioned::Tuple{Vararg{AbstractVector{<:SubsystemStates}}})
-    state_namemap = Dict{Symbol, StateIndex}()
+    state_namemap = OrderedDict{Symbol, StateIndex}()
     for i ∈ eachindex(names_partitioned, states_partitioned)
         for j ∈ eachindex(names_partitioned[i], states_partitioned[i])
             for (k, name) ∈ enumerate(propertynames(states_partitioned[i][j]))
@@ -28,7 +28,7 @@ function compute_namemap(names_partitioned, states_partitioned::Tuple{Vararg{Abs
     state_namemap
 end
 function compute_namemap(names_partitioned, params_partitioned::Tuple{Vararg{AbstractVector{<:SubsystemParams}}})
-    param_namemap = Dict{Symbol, ParamIndex}()
+    param_namemap = OrderedDict{Symbol, ParamIndex}()
     for i ∈ eachindex(names_partitioned, params_partitioned)
         for j ∈ eachindex(names_partitioned[i], params_partitioned[i])
             for name ∈ propertynames(params_partitioned[i][j])


### PR DESCRIPTION
Turns out the order of these things matters, so if you try to pass a solution to a `plot` recipe, the labels get scrambled by the random order of a regular `Dict`. This order should correspond to the actual storage order. 