### PR TITLE
Add Neuroblox integration tests

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           repository: Neuroblox/Neuroblox.jl
           path: downstream
+      - name: Load this and run the downstream tests
         env:
           JULIA_NUM_THREADS: 4
           GROUP: ${{ matrix.group }}
-      - name: Load this and run the downstream tests
         shell: julia --project=downstream {0}
         run: |
           using Pkg

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -7,15 +7,13 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.package.repo }}
+    name: Neuroblox ${{ matrix.group }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         julia-version: [1]
         os: [ubuntu-latest]
-        package:
-          - {user: Neuroblox, repo: Neuroblox.jl}
         group:
           - Basics
           - Advanced

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -15,8 +15,6 @@ jobs:
         julia-version: [1]
         os: [ubuntu-latest]
         group:
-          - Basics
-          - Advanced
           - GraphDynamics1
           - GraphDynamics2
           - GraphDynamics3

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -1,0 +1,57 @@
+name: IntegrationTest
+on:
+  push:
+    branches: [master]
+    tags: [v*]
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.package.repo }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        julia-version: [1]
+        os: [ubuntu-latest]
+        package:
+          - {user: Neuroblox, repo: Neuroblox.jl}
+        group:
+          - Basics
+          - Advanced
+          - GraphDynamics1
+          - GraphDynamics2
+          - GraphDynamics3
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v2
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: x64
+      - uses: julia-actions/julia-buildpkg@latest
+      - name: Clone Downstream
+        uses: actions/checkout@v4
+        with:
+          repository: Neuroblox/Neuroblox.jl
+          path: downstream
+        env:
+          JULIA_NUM_THREADS: 4
+          GROUP: ${{ matrix.group }}
+      - name: Load this and run the downstream tests
+        shell: julia --project=downstream {0}
+        run: |
+          using Pkg
+          try
+            # force it to use this PR's version of the package
+            Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
+            Pkg.update()
+            Pkg.test()  # resolver may fail with test time deps 
+          catch err
+            err isa Pkg.Resolve.ResolverError || rethrow()
+            # If we can't resolve that means this is incompatible by SemVer and this is fine
+            # It means we marked this as a breaking change, so we don't need to worry about
+            # Mistakenly introducing a breaking change, as we have intentionally made one
+
+            @info "Not compatible with this release. No problem." exception=err
+            exit(0)  # Exit immediately, as a success
+          end

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -24,6 +24,7 @@ jobs:
         with:
           version: ${{ matrix.julia-version }}
           arch: x64
+      - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@latest
       - name: Clone Downstream
         uses: actions/checkout@v4


### PR DESCRIPTION
Most of the actual tests of GraphDynamics functionality actually live in [Neuroblox.jl](https://github.com/Neuroblox/Neuroblox.jl), so it's very useful here to have CI run Neuroblox's test suite to make sure changes here don't break stuff in Neuroblox. 

closes #14 

