### PR TITLE
Rename `computed_properies` to `computed_properties`

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,7 +1,9 @@
 name: CI
 on:
-  - push
-  - pull_request
+  - pull_request:
+  push:
+    branches:
+      - master
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,9 +1,8 @@
 name: CI
 on:
-  pull_request
+  pull_request:
   push:
-    branches:
-      - master
+    branches: master
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  - pull_request
+  pull_request
   push:
     branches:
       - master

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,6 @@
 name: CI
 on:
-  - pull_request:
+  - pull_request
   push:
     branches:
       - master

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.2.8"
+version = "0.2.9"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -35,7 +35,7 @@ end
     event_times,
     ForeachConnectedSubsystem,
 
-    computed_properies,
+    computed_properties,
     computed_properties_with_inputs
 )
 

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -169,7 +169,13 @@ let sys = Subsystem{Position}(states=(x=1, y=2), params=(;))
 end
 ```
 """
-computed_properies(s::Subsystem) = (;)
+computed_properties(s::Subsystem) = (;)
+
+# TODO: delete this in the next breaking release.
+# Accidentally released this with computed_properies
+# as the name to use
+const computed_properies = computed_properties
+
 
 """
     computed_properties_with_inputs(s::Subsystem)

--- a/src/subsystems.jl
+++ b/src/subsystems.jl
@@ -187,7 +187,7 @@ function Base.getproperty(s::Subsystem{<:Any, States, Params},
     elseif prop ∈ keys(params)
         getproperty(params, prop)
     else
-        comp_props = computed_properies(s)
+        comp_props = computed_properties(s)
         if prop ∈ keys(comp_props)
             comp_props[prop](s)
         else

--- a/src/symbolic_indexing.jl
+++ b/src/symbolic_indexing.jl
@@ -62,7 +62,7 @@ function make_compu_namemap(names_partitioned::NTuple{N, Vector{Symbol}},
             states = states_partitioned[i][j]
             params = params_partitioned[i][j]
             sys = Subsystem(states, params)
-            for name ∈ keys(computed_properies(sys))
+            for name ∈ keys(computed_properties(sys))
                 requires_inputs = false
                 propname = Symbol(names_partitioned[i][j], "₊", name)
                 namemap[propname] = CompuIndex(i, j, name, requires_inputs)

--- a/test/particle_osc_example.jl
+++ b/test/particle_osc_example.jl
@@ -21,7 +21,7 @@ function GraphDynamics.subsystem_differential(sys::Subsystem{Oscillator}, F, t)
     SubsystemStates{Oscillator}(x=dx, v=dv)
 end
 GraphDynamics.initialize_input(::Subsystem{Oscillator}) = 0.0
-GraphDynamics.computed_properies(::Subsystem{Oscillator}) = (;ω₀ = ((;m, k),) -> √(k/m))
+GraphDynamics.computed_properties(::Subsystem{Oscillator}) = (;ω₀ = ((;m, k),) -> √(k/m))
 
 
 struct Spring <: ConnectionRule


### PR DESCRIPTION
Made a stupid typo in a previous release I didn't notice. 

I added a 
```julia
const computed_properies = computed_properties
```
 so this should be non-breaking