### PR TITLE
Give a more informative error message when `setindex!` on `SubsystemStatesView` fails

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.2.9"
+version = "0.2.10"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"


### PR DESCRIPTION
Instead of the previous unintelligible error message, users will now get something like
```julia
ERROR: Tried to insert a 
SubsystemStates{STN_Blox, Float64, @NamedTuple{V::Float64, n::Float64, m::Float64, h::Float64, G_ctx::Float64}} 
into a vector of 
SubsystemStates{STN_Blox, Float64, @NamedTuple{V::Float64, n::Float64, m::Float64, h::Float64, G::Float64, G_ctx::Float64}}, 
these types must match exactly in order to be valid. This error might occur when 
`subsystem_differential` or similar functions return a SubsystemStates whose fields don't match 
the input states.
```
cc @agchesebro 