### PR TITLE
Fix accidental type instability in `graph_noise!`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.2.10"
+version = "0.2.11"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/graph_solve.jl
+++ b/src/graph_solve.jl
@@ -199,7 +199,7 @@ end
             begin
                 l  = @inbounds length(states_partitioned[i][1])
                 js = @inbounds eachindex(states_partitioned[i])
-                @nexprs $Len j -> begin
+                for j ∈ js
                     @inbounds begin
                         sys = Subsystem(states_partitioned[i][j], params_partitioned[i][j])
                         apply_subsystem_noise!(@view(dstates_partitioned[i].data[:, j]), sys, t)

--- a/src/graph_solve.jl
+++ b/src/graph_solve.jl
@@ -188,22 +188,23 @@ end
 #TODO: We currently only support diagonal noise (that is, the noise source in one
 # equation can't depend on the noise source from another equation). This needs to be
 # generalized, but how to handle it best will require a lot of thought.
-function _graph_noise!(dstates_partitioned#=mutated=#,
+@generated function _graph_noise!(dstates_partitioned#=mutated=#,
                                   states_partitioned ::NTuple{Len, Any},
                                   params_partitioned ::NTuple{Len, Any},
                                   connection_matrices::ConnectionMatrices{NConn},
                                   t) where {Len, NConn}
-
-    idx = 1
-    for i ∈ 1:Len
-        begin
-            l  = @inbounds length(states_partitioned[i][1])
-            js = @inbounds eachindex(states_partitioned[i])
-            @unroll 32 for j ∈ js
-                @inbounds begin
-                    sys = Subsystem(states_partitioned[i][j], params_partitioned[i][j])
-                    apply_subsystem_noise!(@view(dstates_partitioned[i].data[:, j]), sys, t)
-                    idx += l
+    quote
+        idx = 1
+        @nexprs $Len i -> begin
+            begin
+                l  = @inbounds length(states_partitioned[i][1])
+                js = @inbounds eachindex(states_partitioned[i])
+                @nexprs $Len j -> begin
+                    @inbounds begin
+                        sys = Subsystem(states_partitioned[i][j], params_partitioned[i][j])
+                        apply_subsystem_noise!(@view(dstates_partitioned[i].data[:, j]), sys, t)
+                        idx += l
+                    end
                 end
             end
         end


### PR DESCRIPTION
At some point I think I was testing something with `GraphNoise` being a non-generated function and accidentally committed that change. 

This was making it so that stochastic systems experienced a type instability, hugely degrading performance, as seen in @gabrevaya's DBS experiments. 