### PR TITLE
Enable use of `AutoTsit5` via adding a `convert` method for `setindex!(::SubsystemStatesView)`

### DIFF
--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -42,7 +42,7 @@ jobs:
             # force it to use this PR's version of the package
             Pkg.develop(PackageSpec(path="."))  # resolver may fail with main deps
             Pkg.update()
-            Pkg.test()  # resolver may fail with test time deps 
+            Pkg.test(julia_args=["-O1"])  # resolver may fail with test time deps 
           catch err
             err isa Pkg.Resolve.ResolverError || rethrow()
             # If we can't resolve that means this is incompatible by SemVer and this is fine

--- a/.github/workflows/IntegrationTest.yml
+++ b/.github/workflows/IntegrationTest.yml
@@ -35,7 +35,7 @@ jobs:
         env:
           JULIA_NUM_THREADS: 4
           GROUP: ${{ matrix.group }}
-        shell: julia --project=downstream {0}
+        shell: julia --project=downstream {0} -O1
         run: |
           using Pkg
           try

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.2.11"
+version = "0.2.12"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -307,7 +307,7 @@ Base.size(m::ConnectionMatrix{N}) where {N} = (N, N)
 
 abstract type GraphSystem end
 
-@kwdef struct ODEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, Ns, SNM, PNM, CNM} <: GraphSystem
+@kwdef struct ODEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, Ns, EP, SNM, PNM, CNM} <: GraphSystem
     connection_matrices::CM
     states_partitioned::S
     params_partitioned::P
@@ -315,11 +315,12 @@ abstract type GraphSystem end
     composite_discrete_events_partitioned::CDEP = nothing
     composite_continuous_events_partitioned::CCEP = nothing
     names_partitioned::Ns
+    extra_params::EP = (;)
     state_namemap::SNM = make_state_namemap(names_partitioned, states_partitioned)
     param_namemap::PNM = make_param_namemap(names_partitioned, params_partitioned)
     compu_namemap::CNM = make_compu_namemap(names_partitioned, states_partitioned, params_partitioned)
 end
-@kwdef struct SDEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, Ns, SNM, PNM, CNM} <: GraphSystem
+@kwdef struct SDEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, Ns, EP, SNM, PNM, CNM} <: GraphSystem
     connection_matrices::CM
     states_partitioned::S
     params_partitioned::P
@@ -327,6 +328,7 @@ end
     composite_discrete_events_partitioned::CDEP = nothing
     composite_continuous_events_partitioned::CCEP = nothing
     names_partitioned::Ns
+    extra_params::EP = (;)
     state_namemap::SNM = make_state_namemap(names_partitioned, states_partitioned)
     param_namemap::PNM = make_param_namemap(names_partitioned, params_partitioned)
     compu_namemap::CNM = make_compu_namemap(names_partitioned, states_partitioned, params_partitioned)

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -35,12 +35,13 @@ function SciMLBase.SDEProblem(g::SDEGraphSystem, u0map, tspan, param_map=[];
     prob
 end
 
-Base.@kwdef struct GraphSystemParameters{PP, CM, S, STV, DEC}
+Base.@kwdef struct GraphSystemParameters{PP, CM, S, STV, DEC, EP<:NamedTuple}
     params_partitioned::PP
     connection_matrices::CM
     scheduler::S
     state_types_val::STV
     discrete_event_cache::DEC
+    extra_params::EP=(;)
 end
 
 function _problem(g::GraphSystem, tspan; scheduler, allow_nonconcrete, u0map, param_map)

--- a/src/subsystems.jl
+++ b/src/subsystems.jl
@@ -17,10 +17,13 @@ function ConstructionBase.setproperties(s::SubsystemParams{T}, patch::NamedTuple
     props = NamedTuple(s)
     props′ = merge(props, patch)
     if typeof(props) != typeof(props′)
-        error("Type unstable change to subsystem params!")
+        param_setproperror(props, props′)
     end
     SubsystemParams{T}(props′)
 end
+@noinline function param_setproperror(props, props′)
+    error("Type unstable change to subsystem params! Expected properties of type\n  $(typeof(props))\nbut got\n  $(typeof(props′))")
+end 
 
 get_tag(::SubsystemParams{Name}) where {Name} = Name
 get_tag(::Type{<:SubsystemParams{Name}}) where {Name} = Name
@@ -297,8 +300,10 @@ end
 end
 
 function Base.setindex!(v::SubsystemStatesView{States1}, state::States2) where {States1 <: SubsystemStates, States2 <: SubsystemStates}
-    error("Tried to insert a $States2 into a vector of $States1, these types must match exactly in order to be valid. This error might occur when `subsystem_differential` or similar functions return a SubsystemStates whose fields don't match the input states.")
+    state′ = convert(States1, state)
+    setindex!(v, state′)
 end
+
 
 @propagate_inbounds function Base.setindex!(v::SubsystemStatesView{States}, val, s::Symbol) where {States <: SubsystemStates}
     i = state_ind(States, s)


### PR DESCRIPTION
Before:
```julia
julia> using Neuroblox, OrdinaryDiffEq

julia> let
       @named neuron = LIFExciNeuron()
       g = MetaDiGraph()
       add_blox!(g, neuron)
       tspan = (0.0, 2500.0)
       @named sys = system_from_graph(g, graphdynamics=true)
       prob = ODEProblem(sys, [], tspan)
       sol = solve(prob, Tsit5()) # solves just fine
       sol = solve(prob, AutoTsit5(Rodas4())) # errors
       end
Error: $(Big Scary Error)
```
After:
```julia
julia> let
       @named neuron = LIFExciNeuron()
       g = MetaDiGraph()
       add_blox!(g, neuron)
       tspan = (0.0, 2500.0)
       @named sys = system_from_graph(g, graphdynamics=true)
       prob = ODEProblem(sys, [], tspan)
       sol = solve(prob, Tsit5()) # solves just fine
       sol = solve(prob, AutoTsit5(Rodas4()))
       end
retcode: Success
Interpolation: specialized 4th order "free" interpolation, specialized 4rd order "free" stiffness-aware interpolation
t: 17-element Vector{Float64}:
```

This PR also adds an extra params field to the GraphSystems so that I can store learning rules in there later on.