### PR TITLE
Tweaks for synaptic blox

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.2.12"
+version = "0.2.13"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -300,8 +300,9 @@ end
 struct ConnectionMatrices{NConn, Tup <: NTuple{NConn, ConnectionMatrix}}
     matrices::Tup
 end
-Base.getindex(m::ConnectionMatrix, i, j) = m.data[i][j]
-Base.getindex(m::ConnectionMatrices, i) = m.matrices[i]
+@inline Base.getindex(m::ConnectionMatrix, i, j) = m.data[i][j]
+Base.getindex(m::ConnectionMatrix, ::Val{i}, ::Val{j}) where {i, j} = m.data[i][j]
+@inline Base.getindex(m::ConnectionMatrices, i) = m.matrices[i]
 Base.length(m::ConnectionMatrices) = length(m.matrices)
 Base.size(m::ConnectionMatrix{N}) where {N} = (N, N)
 

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -329,7 +329,7 @@ end
     tstops::EVT = Float64[]
     composite_discrete_events_partitioned::CDEP = nothing
     composite_continuous_events_partitioned::CCEP = nothing
-    global_events::GE = nothing
+    global_events::GE = (;)
     names_partitioned::Ns
     extra_params::EP = (;)
     state_namemap::SNM = make_state_namemap(names_partitioned, states_partitioned)

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -307,26 +307,28 @@ Base.size(m::ConnectionMatrix{N}) where {N} = (N, N)
 
 abstract type GraphSystem end
 
-@kwdef struct ODEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, Ns, EP, SNM, PNM, CNM} <: GraphSystem
+@kwdef struct ODEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, GE, Ns, EP, SNM, PNM, CNM} <: GraphSystem
     connection_matrices::CM
     states_partitioned::S
     params_partitioned::P
     tstops::EVT = Float64[]
     composite_discrete_events_partitioned::CDEP = nothing
     composite_continuous_events_partitioned::CCEP = nothing
+    global_events::GE = ()
     names_partitioned::Ns
     extra_params::EP = (;)
     state_namemap::SNM = make_state_namemap(names_partitioned, states_partitioned)
     param_namemap::PNM = make_param_namemap(names_partitioned, params_partitioned)
     compu_namemap::CNM = make_compu_namemap(names_partitioned, states_partitioned, params_partitioned)
 end
-@kwdef struct SDEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, Ns, EP, SNM, PNM, CNM} <: GraphSystem
+@kwdef struct SDEGraphSystem{CM <: ConnectionMatrices, S, P, EVT, CDEP, CCEP, GE, Ns, EP, SNM, PNM, CNM} <: GraphSystem
     connection_matrices::CM
     states_partitioned::S
     params_partitioned::P
     tstops::EVT = Float64[]
     composite_discrete_events_partitioned::CDEP = nothing
     composite_continuous_events_partitioned::CCEP = nothing
+    global_events::GE = nothing
     names_partitioned::Ns
     extra_params::EP = (;)
     state_namemap::SNM = make_state_namemap(names_partitioned, states_partitioned)

--- a/src/graph_solve.jl
+++ b/src/graph_solve.jl
@@ -118,7 +118,7 @@ function combine_inputs end
         @nexprs $Len k -> begin
             @nexprs $NConn nc -> begin
                 @inbounds begin
-                    M = connection_matrices[nc][k, i]
+                    M = connection_matrices[nc].data[k][i] # Same as cm[nc][k,i] but performs better when there's many types
                     input′ = combine_inputs(subsys, M, j, states_partitioned[k], params_partitioned[k], t, SerialScheduler();)
                     input = combine(input, input′)
                 end
@@ -314,7 +314,7 @@ end
         @nexprs $NConn nc -> begin
             @nexprs $Len i -> begin
                 @nexprs $Len k -> begin
-                    M = connection_matrices[nc][k, i]
+                    M = connection_matrices[nc].data[k][i] # Same as cm[nc][k,i] but performs better when there's many types
                     if has_discrete_events(eltype(M))
                         for j ∈ eachindex(states_partitioned[i])
                             for (l, Mlj) ∈ maybe_sparse_enumerate_col(M, j)
@@ -483,7 +483,7 @@ end
         state = init
         @nexprs $Len i -> begin
             @nexprs $NConn nc -> begin
-                M = connection_matrices[nc][k, i]
+                M = connection_matrices[nc].data[k][i] # Same as cm[nc][k,i] but performs better when there's many types
                 if M isa NotConnected
                     nothing
                 else

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -50,7 +50,8 @@ function _problem(g::GraphSystem, tspan; scheduler, allow_nonconcrete, u0map, pa
      connection_matrices,
      tstops,
      composite_discrete_events_partitioned,
-     composite_continuous_events_partitioned,) = g
+     composite_continuous_events_partitioned,
+     global_events) = g
 
     total_eltype = let
         states_eltype = mapreduce(promote_type, states_partitioned) do v
@@ -116,7 +117,7 @@ function _problem(g::GraphSystem, tspan; scheduler, allow_nonconcrete, u0map, pa
 
     ce = nce > 0 ? VectorContinuousCallback(continuous_condition, continuous_affect!, nce) : nothing
     de = nde > 0 ? DiscreteCallback(discrete_condition, discrete_affect!) : nothing
-    callback = CallbackSet(ce, de, composite_discrete_callbacks(composite_discrete_events_partitioned))
+    callback = CallbackSet(ce, de, composite_discrete_callbacks(composite_discrete_events_partitioned), global_events...)
     f = GraphSystemFunction(graph_ode!, g)
     p = GraphSystemParameters(; params_partitioned,
                               connection_matrices,


### PR DESCRIPTION
* Allow users to pass a `global_events` field to a `GraphSystem`. This is used for regular SciML callback objects that act globally on the solver (like those found in SciMLCallbacks.jl)
* Make the compiler not give up on inferring access to the `ConnectionMatrices` when there's many types in them