### PR TITLE
Remove `RecursiveArrayTools.ArrayPartition` -- do partitioning manually

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.2.13"
+version = "0.2.14"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -81,8 +81,6 @@ using SciMLBase:
     ODEFunction,
     SDEFunction
 
-using RecursiveArrayTools: ArrayPartition
-
 using SymbolicIndexingInterface:
     SymbolicIndexingInterface,
     setu,

--- a/src/subsystems.jl
+++ b/src/subsystems.jl
@@ -206,10 +206,12 @@ Base.eltype(::Subsystem{<:Any, T}) where {T} = T
 Base.eltype(::Type{<:Subsystem{<:Any, T}}) where {T} = T
 
 #-------------------------------------------------------------------------
-
-@generated function to_vec_o_states(state_data::NTuple{Len, Any}, ::Val{StateTypes}) where {Len, StateTypes}
-    state_types = StateTypes.parameters
-    Expr(:tuple, (:(VectorOfSubsystemStates{$(state_types[i])}(state_data[$i])) for i ∈ 1:Len)...)
+_deval(::Val{T}) where {T} = T
+function partitioned(v, partition_plan::NTuple{N, Any}) where {N}
+    map(partition_plan) do (;inds, sz, TVal)
+        M = reshape(view(v, inds), sz...)
+        VectorOfSubsystemStates{_deval(TVal)}(M)
+    end
 end
 
 struct VectorOfSubsystemStates{States, Mat <: AbstractMatrix} <: AbstractVector{States}


### PR DESCRIPTION
I accidentally discovered today that almost all of the compilation overhead of GraphDynamics is **not** actually coming from the big `@generated` functions we use like I had assumed, but instead it almost all is caused by passing a `RecursiveArrayTools.ArrayPartition`  to our solvers.

It turns out that by removing the array partition, and performing the partitioning ourselves, I can **substantially** increase the performance of GraphDynamics compilation overhead, and even improve the runtime performance. 

Here's an extreme example with the big version of the corticostriatal model. 

Before:
```julia
julia> big_cortiocostriatal_learning_run()
Construction:   22.041936 seconds (74.87 M allocations: 2.156 GiB, 1.89% gc time, 6 lock conflicts, 107.51% compilation time: 3% of which was recompilation)
Warmed up in: 461.161232 seconds (234.10 M allocations: 9.928 GiB, 0.63% gc time, 97.19% compilation time)
Trial 1 completed in:  29.813890 seconds (6.95 M allocations: 1.111 GiB, 0.70% gc time, 10.99% compilation time)
Trial 2 completed in:  26.465872 seconds (1.18 M allocations: 863.490 MiB, 0.55% gc time)
Trial 3 completed in:  26.457035 seconds (1.18 M allocations: 863.480 MiB, 0.52% gc time)
```
After:
```julia
julia> big_cortiocostriatal_learning_run()
Construction:   22.203149 seconds (75.59 M allocations: 2.187 GiB, 2.72% gc time, 6 lock conflicts, 102.75% compilation time: 3% of which was recompilation)
Warmed up in:  10.285324 seconds (721.07 k allocations: 42.579 MiB, 3.22% compilation time)
Trial 1 completed in:  21.514922 seconds (1.64 M allocations: 876.749 MiB, 0.37% gc time, 6.74% compilation time)
Trial 2 completed in:  19.995818 seconds (352.48 k allocations: 810.296 MiB, 0.29% gc time)
Trial 3 completed in:  19.097529 seconds (352.48 k allocations: 810.296 MiB, 0.26% gc time)
```

This reduced the warmup time from 461 seconds (7.7 minutes!) to just 9.9 seconds, and reduced the compiled runtime from `26.4 seconds` to `19.9 seconds`! 

_______

The benefits of this change can be seen even with more modest systems though. For example, with a system of two Izhikevich neurons connected together, I see 

Before
```julia
  time to construct Problem:   3.097058 seconds (7.01 M allocations: 349.066 MiB, 2.01% gc time, 83.56% compilation time)
  time to first solve:         6.684351 seconds (45.81 M allocations: 2.325 GiB, 9.95% gc time, 99.99% compilation time)
  compiled solve time:         0.000404 seconds (4.85 k allocations: 467.906 KiB)
```
and After:
```julia
  time to construct Problem:   2.749584 seconds (7.11 M allocations: 354.244 MiB, 1.34% gc time, 81.54% compilation time)
  time to first solve:         1.186549 seconds (5.81 M allocations: 308.177 MiB, 3.55% gc time, 99.97% compilation time)
  compiled solve time:         0.000218 seconds (4.08 k allocations: 422.922 KiB)
```

And for 100 Izhikevich neurons connected with 10% sparsity I see 

Before
```julia
  time to construct Problem:   3.194131 seconds (7.69 M allocations: 383.669 MiB, 1.18% gc time, 83.35% compilation time: 2% of which was recompilation)
  time to first solve:         7.035352 seconds (45.94 M allocations: 2.339 GiB, 9.09% gc time, 99.17% compilation time)
  compiled solve time:         0.058035 seconds (36.67 k allocations: 11.025 MiB)
```
After
```julia
  time to construct Problem:   3.399789 seconds (7.79 M allocations: 388.805 MiB, 1.69% gc time, 84.27% compilation time: 3% of which was recompilation)
  time to first solve:         1.494814 seconds (5.91 M allocations: 322.889 MiB, 3.81% gc time, 95.07% compilation time)
  compiled solve time:         0.056628 seconds (10.07 k allocations: 10.567 MiB)
```
So a small but measurable speed improvement here. 