### PR TITLE
Fix Symbolic Indexing with `Num`s.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/MTKExt.jl
+++ b/ext/MTKExt.jl
@@ -2,26 +2,26 @@ module MTKExt
 
 using ModelingToolkit: ModelingToolkit, Num
 using Symbolics: Symbolics, tosymbol
-using GraphDynamics: GraphDynamics, GraphSystem
+using GraphDynamics: GraphDynamics, GraphSystemParameters, PartitionedGraphSystem
 using SymbolicIndexingInterface: SymbolicIndexingInterface
 
-function SymbolicIndexingInterface.is_variable(sys::GraphSystem, var::Num)
+function SymbolicIndexingInterface.is_variable(sys::PartitionedGraphSystem, var::Num)
     SymbolicIndexingInterface.is_variable(sys, tosymbol(var; escape=false))
 end
 
-function SymbolicIndexingInterface.variable_index(sys::GraphSystem, var::Num)
+function SymbolicIndexingInterface.variable_index(sys::PartitionedGraphSystem, var::Num)
     SymbolicIndexingInterface.variable_index(sys, tosymbol(var; escape=false))
 end
 
-function SymbolicIndexingInterface.is_parameter(sys::GraphSystem, var::Num)
+function SymbolicIndexingInterface.is_parameter(sys::PartitionedGraphSystem, var::Num)
     SymbolicIndexingInterface.is_parameter(sys, tosymbol(var; escape=false))
 end
 
-function SymbolicIndexingInterface.parameter_index(sys::GraphSystem, var::Num)
+function SymbolicIndexingInterface.parameter_index(sys::PartitionedGraphSystem, var::Num)
     SymbolicIndexingInterface.parameter_index(sys, tosymbol(var; escape=false))
 end
 
-function SymbolicIndexingInterface.is_independent_variable(sys::GraphSystem, var::Num)
+function SymbolicIndexingInterface.is_independent_variable(sys::PartitionedGraphSystem, var::Num)
     SymbolicIndexingInterface.is_independent_variable(sys, tosymbol(var; escape=false))
 end
 


### PR DESCRIPTION
The `MTKExt` package extension had some out of date dispatches that were stopping symbolic indexing with `Num`s from working. 

e.g.
```julia
using Neuroblox, GraphDynamics, SymbolicIndexingInterface

let
    @named osc1 = HarmonicOscillator()
    @named osc2 = HarmonicOscillator()
    
    g = GraphSystem()
    add_connection!(g, osc1, osc2; weight=1.0)
    add_connection!(g, osc2, osc1; weight=1.0)
    sim_dur = 1e1
    prob = ODEProblem(g, [], (0.0, sim_dur),[])
    
    getp(prob, osc1.ω)(prob)
end
```

Before:

```julia
ERROR: Invalid symbol osc1₊ω for `getp`
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:44
 [2] _getp(sys::ODEProblem{…}, ::ScalarSymbolic, ::ScalarSymbolic, p::Num)
   @ SymbolicIndexingInterface ~/.julia/packages/SymbolicIndexingInterface/vXqJR/src/parameter_indexing.jl:368
 [3] getp(sys::ODEProblem{…}, p::Num)
   @ SymbolicIndexingInterface ~/.julia/packages/SymbolicIndexingInterface/vXqJR/src/parameter_indexing.jl:41
 [4] top-level scope
   @ REPL[18]:11
Some type information was truncated. Use `show(err)` to see complete types.
```
after
```julia
0.15707963267948966
```