### PR TITLE
Implement `DiffEqBase.anyeltypedual` for GraphDynamics types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.4.4"
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"
+DiffEqBase = "2b5f629d-d688-5b77-993f-72d75c75574e"
 OhMyThreads = "67456a42-1dca-4109-a031-0a68de7e3ad5"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 RecursiveArrayTools = "731186ca-8d62-57ce-b412-fbd966d074cd"
@@ -22,6 +23,7 @@ MTKExt = ["Symbolics", "ModelingToolkit"]
 [compat]
 Accessors = "0.1"
 ConstructionBase = "1.5"
+DiffEqBase = "6"
 ModelingToolkit = "9"
 OhMyThreads = "0.6, 0.7, 0.8"
 OrderedCollections = "1.6.3"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.4.4"
+version = "0.4.5"
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"

--- a/ext/MTKExt.jl
+++ b/ext/MTKExt.jl
@@ -25,4 +25,12 @@ function SymbolicIndexingInterface.is_independent_variable(sys::PartitionedGraph
     SymbolicIndexingInterface.is_independent_variable(sys, tosymbol(var; escape=false))
 end
 
+function SymbolicIndexingInterface.is_observed(sys::PartitionedGraphSystem, var::Num)
+    SymbolicIndexingInterface.is_observed(sys, tosymbol(var; escape=false))
+end
+
+function SymbolicIndexingInterface.observed(sys::PartitionedGraphSystem, var::Num)
+    SymbolicIndexingInterface.observed(sys, tosymbol(var; escape=false))
+end
+
 end

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -125,6 +125,9 @@ using OrderedCollections:
     OrderedCollections,
     OrderedDict
 
+using DiffEqBase:
+    DiffEqBase,
+    anyeltypedual
 
 #----------------------------------------------------------
 # Random utils

--- a/src/symbolic_indexing.jl
+++ b/src/symbolic_indexing.jl
@@ -249,8 +249,7 @@ function set_params!!(buffer::GraphSystemParameters, param_map)
         elseif haskey(connection_namemap, key)
             buffer = set_param!!(buffer, key, connection_namemap[key], val)
         else
-            @info "" keys(connection_namemap)
-            error("Key $key does not correspond to a known parameter")
+            error("Key $key does not correspond to a known parameter. ")
         end
     end
     buffer


### PR DESCRIPTION
The PR https://github.com/Neuroblox/GraphDynamics.jl/pull/32 somehow broke a couple things in the Neuroblox.jl docs building pipeline due to how it interacted with the GraphDynamics tutorial. This change (which is good to do anyways) should fix that breakage. It basically just helps the differential equation solvers tell if anything in the problem is a dual number.

I also did a little cleanup of unwanted clutter, and implemented a couple SymbolicIndexingInterface methods for `Num`s with observed variables.