### PR TITLE
Bugfixes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,9 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.4.5"
+version = "0.4.6"
+
+[workspace]
+projects = ["test", "scrap"]
 
 [deps]
 Accessors = "7d9f7c33-5ae7-4f3b-8dc6-eff91059b697"
@@ -19,7 +22,6 @@ Symbolics = "0c5d862f-8b57-4792-8d23-62f2024744c7"
 
 [extensions]
 MTKExt = ["Symbolics", "ModelingToolkit"]
-
 [compat]
 Accessors = "0.1"
 ConstructionBase = "1.5"
@@ -39,6 +41,3 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
 test = ["Test"]
-
-[workspace]
-projects = ["test", "scrap"]

--- a/src/GraphDynamics.jl
+++ b/src/GraphDynamics.jl
@@ -402,7 +402,7 @@ abstract type ConnectionRule end
 (c::ConnectionRule)(src, dst, t) = c(src, dst)
 Base.zero(::T) where {T <: ConnectionRule} = zero(T)
 
-struct NotConnected{CR <: ConnectionRule} end
+struct NotConnected{CR} end
 Base.getindex(::NotConnected{CR}, inds...) where {CR} = zero(CR)
 Base.copy(c::NotConnected) = c
 struct ConnectionMatrix{N, CR, Tup <: NTuple{N, NTuple{N, Union{NotConnected{CR}, AbstractMatrix{CR}}}}}

--- a/src/graph_system.jl
+++ b/src/graph_system.jl
@@ -136,7 +136,7 @@ function PartitionedGraphSystem(g::GraphSystem)
     end
     states_partitioned = (Tuple ∘ map)(v -> map(get_states, v),  subsystems_partitioned)
     params_partitioned = (Tuple ∘ map)(v -> map(get_params, v),  subsystems_partitioned)
-    names_partitioned  = (Tuple ∘ map)(v -> map(x -> convert(Symbol, x.name), v), nodes_partitioned)
+    names_partitioned  = (Tuple ∘ map)(v -> map(x -> convert(Symbol, get_name(x)), v), nodes_partitioned)
 
     #==================================================================================================
     Create a ConnectionMatrices object containing structured information about how each lowest level nodes 

--- a/src/problems.jl
+++ b/src/problems.jl
@@ -102,6 +102,17 @@ function _problem(g::PartitionedGraphSystem, tspan; scheduler, allow_nonconcrete
      param_namemap,
      compu_namemap) = g
 
+    params_partitioned = map(params_partitioned) do v
+        if !isconcretetype(eltype(v))
+            unique_types = unique(typeof.(v))
+            @debug "Non-concrete param types. Promoting" unique_types
+            T = mapreduce(typeof, promote_type, v)
+            convert.(T, v)
+        else
+            v
+        end
+    end
+    
     total_eltype = let
         states_eltype = mapreduce(promote_type, states_partitioned) do v
             eltype(eltype(v))


### PR DESCRIPTION
Fixes:

##### Actually use the `get_name` interface function
##### Promote param vectors in `params_partitioned`
    
This helps avoid some very frustrating performance bugs when e.g. you have something like
```julia
[SubsystemParams{T}(a=1,   b=2)
 SubsystemParams{T}(a=3.0, b=4)]
```
it gets promoted to
```julia
[SubsystemParams{T}(a=1.0, b=2)
 SubsystemParams{T}(a=3.0, b=4)]
```

#####  Don't force NotConnected to only parameterize ConnectionRules

This caused bugs with the new learning pipeline for Neuroblox