### PR TITLE
Compute `connection_namemap` and `is_stochastic` if not given to PartitionedGraphSystem

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "GraphDynamics"
 uuid = "bcd5d0fe-e6b7-4ef1-9848-780c183c7f4c"
-version = "0.4.6"
+version = "0.4.7"
 
 [workspace]
 projects = ["test", "scrap"]


### PR DESCRIPTION
This makes it a bit nicer to work with `PartitionedGraphSystem` directly.